### PR TITLE
Fix point compression tests

### DIFF
--- a/test/pointcompress.test.js
+++ b/test/pointcompress.test.js
@@ -37,14 +37,14 @@ describe('Point compress test for base51', () => {
           fc.bigInt(3n, BigInt(2 ** 254) - 2403n),
           async (a, b, c, d) => {
             const chunk = [];
-            chunk.push(utils.chunkBigInt(a, BigInt(2 ** 85)));
-            chunk.push(utils.chunkBigInt(b, BigInt(2 ** 85)));
-            chunk.push(utils.chunkBigInt(c, BigInt(2 ** 85)));
-            chunk.push(utils.chunkBigInt(d, BigInt(2 ** 85)));
+            chunk.push(utils.pad(utils.chunkBigInt(a, BigInt(2 ** 85)), 3));
+            chunk.push(utils.pad(utils.chunkBigInt(b, BigInt(2 ** 85)), 3));
+            chunk.push(utils.pad(utils.chunkBigInt(c, BigInt(2 ** 85)), 3));
+            chunk.push(utils.pad(utils.chunkBigInt(d, BigInt(2 ** 85)), 3));
             const witness = await cir.calculateWitness({ P: chunk }, true);
             const P = [a, b, c, d];
             const res = utils.point_compress(P);
-            witness.slice(1, 257).every((u, i) => u === res[i]);
+            return witness.slice(1, 257).every((u, i) => u === res[i]);
           },
         ),
       );


### PR DESCRIPTION
Point compression fast checks didn't have padding. causing them to provide insufficient inputs while calculating witness