### PR TITLE
Revert "Base as param in ModulusWith25519Chunked51."

### DIFF
--- a/circuits/modinv.circom
+++ b/circuits/modinv.circom
@@ -9,8 +9,6 @@ template BigModInv51() {
   signal input in[3];
   signal output out[3];
 
-  var base = 85;
-
   var p[3] = [38685626227668133590597613, 38685626227668133590597631, 38685626227668133590597631];
 
   // length k
@@ -30,7 +28,7 @@ template BigModInv51() {
     mult.in1[i] <== in[i];
     mult.in2[i] <== out[i];
   }
-  component mod = ModulusWith25519Chunked51(6, base);
+  component mod = ModulusWith25519Chunked51(6);
   for (var i = 0; i < 6; i++) {
     mod.in[i] <== mult.out[i];
   }

--- a/circuits/modulus.circom
+++ b/circuits/modulus.circom
@@ -336,15 +336,12 @@ template ModulusAgainst2Q() {
   }
 }
 
-template ModulusWith25519Chunked51(n, base) {
-  assert(255 % base == 0);
-
-  var out_bytes = 255 / base;
-
+template ModulusWith25519Chunked51(n) {
   signal input in[n];
-  signal output out[out_bytes];
+  signal output out[3];
 
   var i;
+  var base=85;
 
   component mod2p;
   component mul;
@@ -352,46 +349,46 @@ template ModulusWith25519Chunked51(n, base) {
   component adder;
   component mod2pfinal;
 
-  if (n < out_bytes) {
+  if (n < 3) {
     for (i = 0; i < n; i++) {
       out[i] <== in[i];
     }
 
-    for (i = n; i < out_bytes; i++) {
+    for (i = n; i < 3; i++) {
       out[i] <== 0;
     }
   } else {
     mod2p = ModulusAgainst2PChunked51();
-    for (i = 0; i < out_bytes; i++) {
+    for (i = 0; i < 3; i++) {
       mod2p.in[i] <== in[i];
     }
 
-    mod2p.in[out_bytes] <== 0;
+    mod2p.in[3] <== 0;
 
-    mul = ChunkedMul(n-out_bytes, 1, base);
-    for(i = 0; i < n-out_bytes; i++) {
-      mul.in1[i] <== in[out_bytes+i];
+    mul = ChunkedMul(n-3, 1, base);
+    for(i = 0; i < n-3; i++) {
+      mul.in1[i] <== in[3+i];
     }
 
     mul.in2[0] <== 19;
 
-    mod = ModulusWith25519Chunked51(n-out_bytes+1, base);
-    for (i = 0; i < n-out_bytes+1; i++) {
+    mod = ModulusWith25519Chunked51(n-3+1);
+    for (i = 0; i < n-3+1; i++) {
       mod.in[i] <== mul.out[i];
     }
 
-    adder = ChunkedAdd(out_bytes, 2, base);
-    for (i = 0; i < out_bytes; i++) {
+    adder = ChunkedAdd(3, 2, base);
+    for (i = 0; i < 3; i++) {
       adder.in[0][i] <== mod2p.out[i];
       adder.in[1][i] <== mod.out[i];
     }
 
     mod2pfinal = ModulusAgainst2PChunked51();
-    for (i = 0; i <= out_bytes; i++) {
+    for (i = 0; i < 4; i++) {
       mod2pfinal.in[i] <== adder.out[i];
     }
 
-    for (i = 0; i < out_bytes; i++) {
+    for (i = 0; i < 3; i++) {
       out[i] <== mod2pfinal.out[i];
     }
   }

--- a/circuits/point-addition.circom
+++ b/circuits/point-addition.circom
@@ -135,10 +135,10 @@ template PointAdd(){
         final_mul3.in2[i] <== g_add.sum[i];
     }
 
-    component final_modulo1 = ModulusWith25519Chunked51(17, base);
-    component final_modulo2 = ModulusWith25519Chunked51(17, base);
-    component final_modulo3 = ModulusWith25519Chunked51(20, base);
-    component final_modulo4 = ModulusWith25519Chunked51(14, base);
+    component final_modulo1 = ModulusWith25519Chunked51(17);
+    component final_modulo2 = ModulusWith25519Chunked51(17);
+    component final_modulo3 = ModulusWith25519Chunked51(20);
+    component final_modulo4 = ModulusWith25519Chunked51(14);
 
     for(i=0;i<17;i++){
         final_modulo1.in[i] <== final_mul1.out[i];

--- a/circuits/pointcompress.circom
+++ b/circuits/pointcompress.circom
@@ -9,13 +9,12 @@ template PointCompress(){
     signal input P[4][3];
     signal output out[256];
     var i;
-    var base=85;
 
     component mul_x = ChunkedMul(3, 3, 85);
     component mul_y = ChunkedMul(3, 3, 85);
     component modinv_z = BigModInv51();
-    component mod_x = ModulusWith25519Chunked51(6, base);
-    component mod_y = ModulusWith25519Chunked51(6, base);
+    component mod_x = ModulusWith25519Chunked51(6);
+    component mod_y = ModulusWith25519Chunked51(6);
     
     for(i=0;i<3;i++){
         modinv_z.in[i] <== P[2][i];

--- a/circuits/verify.circom
+++ b/circuits/verify.circom
@@ -117,8 +117,6 @@ template PointEqual() {
 
   var i;
   var j;
-  var base=85;
-
   component mul[4];
   for (i=0; i<4; i++) {
     mul[i] = ChunkedMul(3, 3, 85);
@@ -144,7 +142,7 @@ template PointEqual() {
 
   component mod[4];
   for (i=0; i<4; i++) {
-    mod[i] = ModulusWith25519Chunked51(6, base);
+    mod[i] = ModulusWith25519Chunked51(6);
   }
   
   for(i=0; i<6; i++) {

--- a/test/circuits/chunkedmodulus.circom
+++ b/test/circuits/chunkedmodulus.circom
@@ -2,4 +2,4 @@ pragma circom 2.0.0;
 
 include "../../circuits/modulus.circom";
 
-component main = ModulusWith25519Chunked51(20, 85);
+component main = ModulusWith25519Chunked51(20);


### PR DESCRIPTION
Reverts Electron-Labs/ed25519-circom#74

Since Modulus With 25519 is specific to this circuit and not the generic big int library, the most performant base(85) will always be used. Furthermore, it is almost impossible to generalize modulus against 2p chunked without increasing the number of constraints and doing additional calculation